### PR TITLE
Changed move() to be a pure virtual function

### DIFF
--- a/src/pieces.cpp
+++ b/src/pieces.cpp
@@ -46,9 +46,3 @@ int getyCoordinate()
 {
 	return yCoordinate;
 }
-
-void move()
-{
-	//This is going to be an overloaded function. I don't know what to 
-	//do here. 
-}

--- a/src/pieces.h
+++ b/src/pieces.h
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <string>
 
-class Pieces 
+class Pieces
 {
 	protected:
 		string pieceColor = 'NULL';
@@ -21,7 +21,6 @@ class Pieces
 		int getxCoordinate();
 		void setyCoordinate(int location);
 		int getyCoordinate();
-		void move();
+		virtual void move(int newXLocation, int newYLocation) = 0;
 
 } Pieces;
-


### PR DESCRIPTION
* Removed the definition of move() from peices.cpp. Virtual functions don't have a definition in the base class.

* Added virtual tag and "=0" to move() declaration to make it virtual. Now all children of Pieces must define their own move(int newXLocation, int newYLocation) method.